### PR TITLE
Downgrade to ractive v0.8.12

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.9/validator.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.4/js/standalone/selectize.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.perfect-scrollbar/0.6.12/js/perfect-scrollbar.jquery.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ractive/0.9.0-build-117/ractive.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ractive/0.8.12/ractive.min.js"></script>
         <script src="https://cdn.rawgit.com/jmespath/jmespath.js/master/jmespath.js"></script>
 
         <script src="js/define-property.js"></script>

--- a/material.html
+++ b/material.html
@@ -45,7 +45,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.9/validator.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.4/js/standalone/selectize.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.perfect-scrollbar/0.6.12/js/perfect-scrollbar.jquery.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ractive/0.9.0-build-117/ractive.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ractive/0.8.12/ractive.min.js"></script>
         <script src="https://cdn.rawgit.com/jmespath/jmespath.js/master/jmespath.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.5.10/js/material.min.js"></script>
 

--- a/nomaterial.html
+++ b/nomaterial.html
@@ -46,7 +46,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.9/validator.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.4/js/standalone/selectize.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.perfect-scrollbar/0.6.12/js/perfect-scrollbar.jquery.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ractive/0.9.0-build-117/ractive.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ractive/0.8.12/ractive.min.js"></script>
         <script src="https://cdn.rawgit.com/jmespath/jmespath.js/master/jmespath.js"></script>
     
         <script src="js/define-property.js"></script>


### PR DESCRIPTION
https://trello.com/c/AwEIQgFy/378-group-name-data-breaks-ractive

Related to https://github.com/ractivejs/ractive/issues/2954