### PR TITLE
Fix radio buttons disappearing

### DIFF
--- a/js/ractive-legalform.js
+++ b/js/ractive-legalform.js
@@ -91,10 +91,10 @@
         onChangeLegalForm: function (newValue, oldValue, keypath) {
             if (this.isCondition(keypath)) {
                 this.onChangeCondition(newValue, oldValue, keypath);
-                
-                if ($(this.el).hasClass('material')) {
-                    $(this.el).toMaterial();
-                }
+            }
+            
+            if ($(this.el).hasClass('material')) {
+                $(this.el).toMaterial();
             }
 
             this.updateExpressions(newValue, oldValue, keypath);


### PR DESCRIPTION
Sometimes the observer isn't called for every new keypath, so calling toMaterial() when the keypath is a conditional won't always work.