### PR TITLE
Minor fixes for label & selectize fields

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -271,6 +271,17 @@
     font-weight: 300;
 }
 
+.material .form-group > label {
+    top: 1rem;
+    left: 0;
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    width: 100%;
+    overflow: hidden;
+    max-width: 100%;
+    white-space: nowrap;
+}
+
 .material .form-group.has-danger .form-control,
 .material .form-group.has-error .form-control {
     box-shadow: none;
@@ -306,11 +317,17 @@
 }
 
 .material .selectize-input {
-    min-height: 46px;
+    min-height: 32px;
+    height: 32px;
 }
 
 .material .selectize-input .item {
     padding: 7px 0px;
+    max-width: 95%;
+    width: 95%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .material .label-addon {


### PR DESCRIPTION
## Preview

Labels are now a single-line label that gets truncated if it is too long.
![image](https://user-images.githubusercontent.com/2484595/34382591-377b827c-eb10-11e7-8dc8-570977d84270.png)

Fixes selectized fields padding & also puts the options on a single line
![image](https://user-images.githubusercontent.com/2484595/34382618-7cafd302-eb10-11e7-8ba2-c912b4f2dc1f.png)
