### PR TITLE
Encode %value% in external_source

### DIFF
--- a/js/ractive-legalform.js
+++ b/js/ractive-legalform.js
@@ -695,7 +695,7 @@
                         if (!send) return callback();
 
                         this.settings.score = useValue ? score : false;
-                        url = ltriToUrl(url).replace('%value%', encodeURI(query));
+                        url = ltriToUrl(url).replace('%value%', encodeURIComponent(query));
                         url = clearComputedUrl(url);
 
                         xhr = $.ajax({


### PR DESCRIPTION
Use encodeURIComponent() instead of encodeURI() if only part of a URI has to be encoded.