### PR TITLE
check if validator is set

### DIFF
--- a/js/ractive-legalform.js
+++ b/js/ractive-legalform.js
@@ -592,7 +592,12 @@
                     var $stepForm = $(this);
                     var validator = $stepForm.data('bs.validator');
 
-                    if (!validator) return false;
+                    if (!validator) {
+                        console.log('Reinitializing validator...');
+                        self.initBootstrapValidation();
+                        self.updateBootstrapValidation();
+                        return;
+                    }
 
                     validator.update();
                     validator.validate();

--- a/js/ractive-legalform.js
+++ b/js/ractive-legalform.js
@@ -592,6 +592,8 @@
                     var $stepForm = $(this);
                     var validator = $stepForm.data('bs.validator');
 
+                    if (!validator) return false;
+
                     validator.update();
                     validator.validate();
 


### PR DESCRIPTION
This validator is not always set (i.e. when entering certain values in the 'wijzigen-onderneming' flow). Without this check, it simply crashed and does not load the rest of the form.